### PR TITLE
Add link to latest AWS blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ aws lambda publish-layer-version \
 
 ## Resources
 ### AWS Blog posts & documentation
-* Blog Post 1
+* https://aws.amazon.com/blogs/compute/introducing-the-new-serverless-lamp-stack/
 * https://aws.amazon.com/blogs/apn/aws-lambda-custom-runtime-for-php-a-practical-example/
 * https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html
 


### PR DESCRIPTION
*Description of changes:*

I figured that this was a placeholder for the 1st blog post regarding PHP? I added the link to https://aws.amazon.com/blogs/compute/introducing-the-new-serverless-lamp-stack/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
