### PR TITLE
Add article full author name instead of nickname

### DIFF
--- a/serverless-php-resources.md
+++ b/serverless-php-resources.md
@@ -19,7 +19,7 @@ This community curated list of serverless/PHP resources helps likeminded PHP dev
 - ["Compiling wkhtmltopdf for use inside an AWS Lambda function with Bref is easier than you'd think"](https://tech.mybuilder.com/compiling-wkhtmltopdf-aws-lambda-with-bref-easier-than-you-think/) - *Neal Brooks*
 - ["Deploying Laravel Artisan on AWS Lambda"](https://blog.deleu.dev/deploying-laravel-artisan-on-aws-lambda/) - *Marco Aurélio Deleu*
 - ["Deploy Static Frontend + PHP Files Using ZEIT Now"](https://dev.to/nx1/deploy-static-frontend-php-files-using-zeit-now-mg) - *Milan Felix Šulc*
-- ["Going serverless with PHP"](https://medium.com/php-fad/going-serverless-with-php-f5a67cb3d67b) - *Kpicaza*
+- ["Going serverless with PHP"](https://medium.com/php-fad/going-serverless-with-php-f5a67cb3d67b) - *Koldo Picaza Rodríguez*
 - ["Introducing the new Serverless LAMP stack"](https://aws.amazon.com/blogs/compute/introducing-the-new-serverless-lamp-stack/) - *Benjamin Smith*
 - ["PHPUnit with Bref"](https://blog.deleu.dev/phpunit-with-bref/) - *Marco Aurélio Deleu*
 - ["Responding to SMS in PHP using AWS Lambda and Bref"](https://www.twilio.com/blog/responding-to-sms-in-php-using-aws-lambda-and-bref-php) - *Gary Hockin*


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add full author name to the article named "Going serverless with PHP", added in the PR https://github.com/aws-samples/php-examples-for-aws-lambda/pull/5. Thank you very much for sharing the article;-D

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
