### PR TITLE
Fix restricting S3 assets access.

### DIFF
--- a/0.4-Building-A-Serverless-Laravel-App-With-AWS-SAM/template.yaml
+++ b/0.4-Building-A-Serverless-Laravel-App-With-AWS-SAM/template.yaml
@@ -99,7 +99,8 @@ Resources:
         # The assets (S3)
             -   Id: Assets
                 DomainName: !GetAtt Assets.RegionalDomainName
-                S3OriginConfig: {} # this key is required to tell CloudFront that this is an S3 origin, even though nothing is configured
+                S3OriginConfig:
+                  OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${S3OriginIdentityExample}"
         # The default behavior is to send everything to AWS Lambda
         DefaultCacheBehavior:
           AllowedMethods: [GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE]


### PR DESCRIPTION
As it stands, the `S3OriginIdentityExample` has **not** been associated with the `Cloudfrontdistribution` resulting in access denied errors when attempting to fetch assets.

This is fixed by creating said association between these two resources.

Unexpected behavior found & fixed through https://github.com/rdok/aws-sam-laravel/commit/acaddccefb5b56ced269ccffb410a8a6c543bc83 -> https://aws-sam-laravel-local.rdok.co.uk/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
