### PR TITLE
Removed non-ASCII characters from example

### DIFF
--- a/0.2-Relational-Database-RDS-Proxy-Example/README.md
+++ b/0.2-Relational-Database-RDS-Proxy-Example/README.md
@@ -84,7 +84,7 @@ aws iam create-policy \
         "secretsmanager:ListSecretVersionIds"
       ],
       "Resource": [
-        "<the-arn-of-the-secret>”
+        "<the-arn-of-the-secret>"
       ]
     },
     {


### PR DESCRIPTION
That non-ASCII character threw an error when using the example docs. It looks identical, so it took a while to notice.

*Issue #, if available:*

*Description of changes:*

Updated example snippet from README docs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
