### PR TITLE
Updating index function to run in deployed state

### DIFF
--- a/0.7-PHP-Lambda-functions-with-Docker-container-images/readme.md
+++ b/0.7-PHP-Lambda-functions-with-Docker-container-images/readme.md
@@ -27,10 +27,11 @@ docker run -p 9000:8080 phpmyfunction:latest
 3. This command starts up a local endpoint at `localhost:9000/2015-03-31/functions/function/invocations`
 
 
-4.	Post an event to this endpoint using a curl command. The Lambda function payload is provided by using the -d flag.  This is a valid Json object required by the Runtime Interface Emulator:
+4.	Post an event to this endpoint using a curl command. The Lambda function payload is provided by using the -d flag. Because API Gateway encodes the body in base64, we need to pipe the function payload through base64 and route that into our curl command, this way the php will function both locally and deployed.  This is a valid Json object required by the Runtime Interface Emulator:
 
 ```bash 
-curl "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{"queryStringParameters": {"name":"Ben"}}'
+(echo -n '{"body": "'; echo '{"queryStringParameters": {"name":"Ben"}}' | base64; echo '"}') |
+curl -d @-  http://localhost:9000/2015-03-31/functions/function/invocations
 ```
 
 5. A 200 status response is returned:

--- a/0.7-PHP-Lambda-functions-with-Docker-container-images/src/index.php
+++ b/0.7-PHP-Lambda-functions-with-Docker-container-images/src/index.php
@@ -21,7 +21,7 @@
 //hello function
 function index($data)
 {
-    return APIResponse("Hello, ". $data['queryStringParameters']['name']);
+    return APIResponse("Hello, ". json_decode(base64_decode($data['body']), true)['queryStringParameters']['name']);
 }
 
 function APIResponse($body)


### PR DESCRIPTION
*Issue #, if available:* #33

*Description of changes:* Updated the index.php to decode base64 and decode the json element within, this allows the index file to run as intended once deployed to lambda as API GW will base64 encode the payload as "body" before sending to lambda. Also updated the readme file to include an updated curl command that injects the json payload as a base64 encoded body object. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
