### PR TITLE
multiple serverless lamp fixes to work on current

### DIFF
--- a/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/README.md
+++ b/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/README.md
@@ -39,7 +39,7 @@ Install [Bref](https://github.com/brefphp/bref) using either composer or docker;
 1. Composer:
 
   ```bash
-  composer require bref/bref
+  composer update
   ```
 
 2. Docker:

--- a/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/README.md
+++ b/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/README.md
@@ -34,11 +34,20 @@ change to the correct directory:
 cd 0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks
 ```
 
-Install [Bref](https://github.com/brefphp/bref) using Composer:
+Install [Bref](https://github.com/brefphp/bref) using either composer or docker;
 
-```bash
-composer require bref/bref
-```
+1. Composer:
+
+  ```bash
+  composer require bref/bref
+  ```
+
+2. Docker:
+ 
+  ```bash
+  docker run --rm --interactive --tty --volume $PWD:/app composer update
+  ```
+
 
 Deploy the stack: This command uses SAM CLI, but you could also deploy with the [serverless framework](https://www.serverless.com/):
 

--- a/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/composer.json
+++ b/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/composer.json
@@ -1,0 +1,11 @@
+{
+    "config": {
+        "platform": {
+            "php": "8.1"
+        }
+    },
+    "require": {
+        "bref/bref": "^1.5",
+        "php": ">=8.1"
+    }
+}

--- a/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/template.yaml
+++ b/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/template.yaml
@@ -11,12 +11,20 @@ Globals:
     
 Resources:
 ##########################################################################
+#  API Gateway with stage name                                           #
+##########################################################################  
+  HttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: dev
+
+##########################################################################
 #  S3 Bucket to store static assets                                      #
 ##########################################################################  
   Assets:
     Type: AWS::S3::Bucket
     Properties:
-        BucketName: php-example-assets-for-php-app-example-3
+        BucketName: !Sub 'cf-origin-${AWS::AccountId}-${AWS::StackName}'
    # The policy that makes the bucket publicly readable
   AssetsBucketPolicy: 
     Type: AWS::S3::BucketPolicy
@@ -52,16 +60,18 @@ Resources:
       Timeout: 30
       Tracing: Active
       Layers:
-        - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:25'
+        - !Sub 'arn:aws:lambda:${AWS::Region}:209497400698:layer:php-81-fpm:19'
       Events:
         DynamicRequestsRoot:
           Type: HttpApi
           Properties:
+            ApiId: !Ref HttpApi
             Path: /
             Method: ANY
         DynamicRequestsProxy:
           Type: HttpApi
           Properties:
+            ApiId: !Ref HttpApi
             Path: /{proxy+}
             Method: ANY
 ##########################################################################
@@ -74,7 +84,7 @@ Resources:
         Enabled: true 
         Origins:
             -   Id: Website  
-                DomainName: !Join ['.', [!Ref ServerlessHttpApi, 'execute-api', !Ref AWS::Region, 'amazonaws.com']]
+                DomainName: !Sub '${HttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}'
                 # This is the stage
                 OriginPath: "/dev"
                 CustomOriginConfig:
@@ -82,7 +92,8 @@ Resources:
         # The assets (S3)
             -   Id: Assets
                 DomainName: !GetAtt Assets.RegionalDomainName
-                S3OriginConfig: {} # this key is required to tell CloudFront that this is an S3 origin, even though nothing is configured
+                S3OriginConfig:
+                  OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${S3OriginIdentityExample}'
         # The default behavior is to send everything to AWS Lambda
         DefaultCacheBehavior:
           AllowedMethods: [GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE]

--- a/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/template.yaml
+++ b/0.3-Replacing-The-HTTP-Web-Server-For-Traditional-PHP-Frameworks/template.yaml
@@ -54,7 +54,7 @@ Resources:
     Properties:
       Description: Lambda function to hosts entire application codebase
       CodeUri: .
-      Runtime: provided
+      Runtime: provided.al2 # the layer and runtime need to be the same
       Handler: index.php
       MemorySize: 1024
       Timeout: 30


### PR DESCRIPTION
*Issue #30 , if available:*

*Description of changes:*

- fixed issue #30 
- added serverless HttpApi resource for referencing later in CF origin
- ensure lambda layer is pulled from same aws region
- updated breh and php to current versions
- fixed lambda runtime issue with layer mismatch
- this deploys cleanly following readme instructions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
